### PR TITLE
fixes: ModuleRef broken DI juicyllama/framework#69, TypeORM Issue juicyllama/framework#70

### DIFF
--- a/backend/client-install.sh
+++ b/backend/client-install.sh
@@ -9,16 +9,7 @@ echo 'Installing backend project'
 rm -rf node_modules
 rm -rf pnpm-lock.yaml
 pnpm install --shamefully-hoist || (echo 'Cannot install backend packages' && exit)
-pnpm run link || (echo 'Cannot link backend project packages' && exit) 
+pnpm run link || (echo 'Cannot link backend project packages' && exit)
 npx jl install || (echo 'Cannot install backend project' && exit)
-
-
-######### TEMP FIX: https://github.com/orgs/juicyllama/projects/8/views/1?pane=issue&itemId=45264661
-
-cd node_modules/@nestjs
-rm -rf core/
-ln -s ../../../../../framework/node_modules/@nestjs/core || ln -s ../../../../framework/node_modules/@nestjs/core || (echo 'Cannot find framework folder on local file system' && exit)
-
-##########
 
 cd ..

--- a/backend/pnpm-link.sh
+++ b/backend/pnpm-link.sh
@@ -3,3 +3,7 @@ pnpm link --global @juicyllama/cli
 pnpm link --global @juicyllama/dev
 pnpm link --global @juicyllama/core
 pnpm link --global @juicyllama/utils
+
+# NestJS
+pnpm link --global @nestjs/core
+pnpm link --global @nestjs/typeorm


### PR DESCRIPTION
Link global `@nestjs` packages to the backend.
Assuming those are linked from framework before, this forces client-quickstart and framework use the same instance of `@nestjs/core` and `@nestjs/typeorm` packages, resolving DI and TypeOrm metadata issues