### PR TITLE
TypeORM Issue juicyllama/framework#70: cleanup of the previous temporary fix

### DIFF
--- a/backend/src/modules/animals/animals.module.ts
+++ b/backend/src/modules/animals/animals.module.ts
@@ -3,14 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm'
 import { JwtModule } from '@nestjs/jwt'
 import { Logger } from '@juicyllama/utils'
 import {
-	Account,
 	BeaconModule,
 	databaseConfig,
 	jwtConfig,
 	Query,
-	Role,
-	Tag,
-	User,
 } from '@juicyllama/core'
 import { Animal } from './animals.entity'
 import { AnimalsService } from './animals.service'
@@ -20,8 +16,7 @@ import { AnimalsController } from './animals.controller'
 	imports: [
 		JwtModule.register(jwtConfig()),
 		TypeOrmModule.forRoot(databaseConfig()),
-		//TypeOrmModule.forFeature([Animal]), //awaiting fix as per https://github.com/juicyllama/framework/issues/70 
-		TypeOrmModule.forFeature([Animal, User, Account, Tag, Role]),
+		TypeOrmModule.forFeature([Animal]),
 		forwardRef(() => BeaconModule),
 	],
 	controllers: [AnimalsController],


### PR DESCRIPTION
this is a follow-up for the previous temporary fix, which should not be needed anymore.